### PR TITLE
Allow override of packages to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ actually attach & mount a volume you have to use the defined type
 * Type: `String`
 * Default: `'/etc/systemd/system'`
 
+##### `packages`
+
+* list of packages to install
+* Type: `Array`
+* Default: `[ 'curl', 'gawk', 'util-linux', 'awscli', 'xfsprogs' ]`
+
 #### Examples
 
 ##### Declaring the base class

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,8 +13,9 @@
 # @param bin_dir path to the binary directory for helper scripts
 # @param systemd_dir path to the directory where systemd units should be placed
 class aws_ebs(
-  String $systemd_dir = '/etc/systemd/system',
-  String $bin_dir = '/opt/bin',
+  String $systemd_dir     = '/etc/systemd/system',
+  String $bin_dir         = '/opt/bin',
+  Array[String] $packages = ['curl', 'gawk', 'util-linux', 'awscli', 'xfsprogs'],
 ){
 
   $path = defined('$::path') ? {
@@ -27,7 +28,7 @@ class aws_ebs(
     mode =>  '0755',
   })
 
-  ensure_resource('package', ['curl', 'gawk', 'util-linux', 'awscli', 'xfsprogs'],{
+  ensure_resource('package', $packages,{
     ensure => present
   })
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -63,6 +63,7 @@ define aws_ebs::mount(
     notify  => Exec[$systemd_reload],
   } ~> service { $mount_service_name:
     ensure  => running,
+    enable  => true,
     require => Exec[$systemd_reload],
   }
 }


### PR DESCRIPTION
- add `packages` parameter to allow the override of packages to be
  installed.  For example, some packages in the list may need to be
  omitted if they are installed via another module in the catalog.

- the default package list is set to ensure existing behaviour is
  preserved.